### PR TITLE
Adjusted AWS INC 5424 fix and validation to require SG scoped rules

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -104,7 +104,7 @@ You're on call. Four tickets just came in. Your job: diagnose and fix.
 > "Our quarterly security scan flagged several issues with the network segmentation:
 > 
 > 1. SSH is accessible from the internet on some hosts (should only be via bastion)
-> 2. Database accepts connections from too broad a range (should be API tier only)
+> 2. Database accepts connections from too broad a range (should be API tier only; SG-scoped is preferred)
 > 3. ICMP is open from anywhere
 > 
 > These need to be tightened up before our compliance review next week."


### PR DESCRIPTION
Note: Did not include Azure in this fix as that would require doing so via Application Security Groups and I felt that could be slightly out of scope for the fundamentals.

This pull request strengthens the security group validation logic for AWS resources by enforcing that all SSH, database, and ICMP access is strictly security group (SG)-scoped, eliminating the use of broad CIDR ranges. The changes update both documentation and the validation script to reflect and enforce these stricter requirements.

Security group validation improvements:

* The `validate.sh` script now enforces that SSH access to `WEB_SG_ID`, `API_SG_ID`, and `DB_SG_ID` is only allowed from the bastion security group (`BASTION_SG_ID`) via SG references, and not via any CIDR ranges.
* Database access to `DB_SG_ID` is now validated to ensure only the API security group (`API_SG_ID`) can connect, exclusively via SG reference on TCP port 5432, with no CIDR ranges or overly broad port rules allowed.
* ICMP access to `WEB_SG_ID` is restricted to only allow traffic from the bastion SG, again with no CIDR ranges permitted.

Documentation update:

* The incident description in `aws/README.md` was updated to clarify that database connectivity should be SG-scoped, not CIDR-based.