### PR TITLE
INC-4524 more clarity and context based on validation

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -114,8 +114,8 @@ You're on call. Four tickets just came in. Your job: diagnose and fix.
 
 > "Our quarterly security scan flagged several issues with the network segmentation:
 > 
-> 1. SSH is accessible from the internet on some hosts (should only be via bastion)
-> 2. Database accepts connections from too broad a range (should be API tier only; SG-scoped is preferred)
+> 1. SSH is accessible from the internet on some hosts, including bastion (only your trusted source IP/CIDR should be allowed)
+> 2. Database accepts connections from too broad a range (should be API tier only)
 > 3. ICMP is open from anywhere
 > 
 > These need to be tightened up before our compliance review next week."

--- a/aws/README.md
+++ b/aws/README.md
@@ -114,9 +114,9 @@ You're on call. Four tickets just came in. Your job: diagnose and fix.
 
 > "Our quarterly security scan flagged several issues with the network segmentation:
 > 
-> 1. SSH is accessible from the internet on all hosts — bastion should only allow SSH from your trusted source IP/CIDR, and internal hosts (web, API, database) should only allow SSH from the bastion
-> 2. Database accepts connections on port 5432 from too broad a range — it should only accept connections from the API tier
-> 3. ICMP is open from anywhere on the web server — it should only be allowed from the bastion host
+> 1. SSH is accessible from the internet on all hosts — bastion should only allow SSH from your trusted source IP/CIDR, and internal hosts (web, API, database) should only allow SSH from the bastion security group
+> 2. Database accepts connections on port 5432 from too broad a range — it should only accept connections from the API security group
+> 3. ICMP is open from anywhere on the web server — it should only be allowed from the bastion security group
 > 
 > These need to be tightened up before our compliance review next week."
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -114,9 +114,9 @@ You're on call. Four tickets just came in. Your job: diagnose and fix.
 
 > "Our quarterly security scan flagged several issues with the network segmentation:
 > 
-> 1. SSH is accessible from the internet on some hosts, including bastion (only your trusted source IP/CIDR should be allowed)
-> 2. Database accepts connections from too broad a range (should be API tier only)
-> 3. ICMP is open from anywhere
+> 1. SSH is accessible from the internet on all hosts — bastion should only allow SSH from your trusted source IP/CIDR, and internal hosts (web, API, database) should only allow SSH from the bastion
+> 2. Database accepts connections on port 5432 from too broad a range — it should only accept connections from the API tier
+> 3. ICMP is open from anywhere on the web server — it should only be allowed from the bastion host
 > 
 > These need to be tightened up before our compliance review next week."
 

--- a/aws/scripts/validate.sh
+++ b/aws/scripts/validate.sh
@@ -167,7 +167,17 @@ validate_inc_4523() {
 validate_inc_4524() {
     local ALL_PASS=true
 
-    # Check 1: SSH source restriction (SG-scoped only; no CIDR)
+    # Check 1: Bastion SSH source restriction (must not be internet-open)
+    local BASTION_SSH_CIDRS=$(aws ec2 describe-security-groups --group-ids "$BASTION_SG_ID" \
+        --query "SecurityGroups[0].IpPermissions[?FromPort==\`22\` && ToPort==\`22\`].IpRanges[].CidrIp" --output text 2>/dev/null)
+    local BASTION_SSH_SG_SOURCES=$(aws ec2 describe-security-groups --group-ids "$BASTION_SG_ID" \
+        --query "SecurityGroups[0].IpPermissions[?FromPort==\`22\` && ToPort==\`22\`].UserIdGroupPairs[].GroupId" --output text 2>/dev/null)
+
+    if [ -z "$BASTION_SSH_CIDRS" ] || [ -n "$BASTION_SSH_SG_SOURCES" ] || echo "$BASTION_SSH_CIDRS" | grep -q "0.0.0.0/0"; then
+        ALL_PASS=false
+    fi
+
+    # Check 2: SSH source restriction on internal tiers (SG-scoped only; no CIDR)
     for SG_ID in "$WEB_SG_ID" "$API_SG_ID" "$DB_SG_ID"; do
         local SSH_CIDRS=$(aws ec2 describe-security-groups --group-ids "$SG_ID" \
             --query "SecurityGroups[0].IpPermissions[?FromPort==\`22\` && ToPort==\`22\`].IpRanges[].CidrIp" --output text 2>/dev/null)
@@ -187,7 +197,7 @@ validate_inc_4524() {
         fi
     done
 
-    # Check 2: Database source restriction (API SG only, TCP/5432 only, SG-scoped)
+    # Check 3: Database source restriction (API SG only, TCP/5432 only, SG-scoped)
     local DB_CIDRS=$(aws ec2 describe-security-groups --group-ids "$DB_SG_ID" \
         --query "SecurityGroups[0].IpPermissions[?IpProtocol=='tcp' && FromPort==\`5432\` && ToPort==\`5432\`].IpRanges[].CidrIp" --output text 2>/dev/null)
     local DB_SG_SOURCES=$(aws ec2 describe-security-groups --group-ids "$DB_SG_ID" \
@@ -211,7 +221,7 @@ validate_inc_4524() {
         done
     fi
 
-    # Check 3: ICMP restriction (SG-scoped only; no CIDR)
+    # Check 4: ICMP restriction (SG-scoped only; no CIDR)
     local ICMP_CIDRS=$(aws ec2 describe-security-groups --group-ids "$WEB_SG_ID" \
         --query "SecurityGroups[0].IpPermissions[?IpProtocol==\`icmp\`].IpRanges[].CidrIp" --output text 2>/dev/null)
     local ICMP_SG_SOURCES=$(aws ec2 describe-security-groups --group-ids "$WEB_SG_ID" \

--- a/azure/README.md
+++ b/azure/README.md
@@ -114,9 +114,9 @@ You're on call. Four tickets just came in. Your job: diagnose and fix.
 
 > "Our quarterly security scan flagged several issues with the network segmentation:
 > 
-> 1. SSH is accessible from the internet on some hosts, including bastion (only your trusted source IP/CIDR should be allowed)
-> 2. Database accepts connections from too broad a range (should be API tier only)
-> 3. ICMP is open from anywhere
+> 1. SSH is accessible from the internet on all hosts — bastion should only allow SSH from your trusted source IP/CIDR, and internal hosts (web, API, database) should only allow SSH from the bastion subnet
+> 2. Database accepts connections on port 5432 from too broad a range — it should only accept connections from the API subnet (10.0.2.0/24)
+> 3. ICMP is open from anywhere on the web server — it should only be allowed from the bastion subnet
 > 
 > These need to be tightened up before our compliance review next week."
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -114,8 +114,8 @@ You're on call. Four tickets just came in. Your job: diagnose and fix.
 
 > "Our quarterly security scan flagged several issues with the network segmentation:
 > 
-> 1. SSH is accessible from the internet on some hosts (should only be via bastion)
-> 2. The database is directly accessible from the bastion host on port 5432 — it should only be reachable from the API tier subnet
+> 1. SSH is accessible from the internet on some hosts, including bastion (only your trusted source IP/CIDR should be allowed)
+> 2. Database accepts connections from too broad a range (should be API tier only)
 > 3. ICMP is open from anywhere
 > 
 > These need to be tightened up before our compliance review next week."

--- a/azure/scripts/validate.sh
+++ b/azure/scripts/validate.sh
@@ -156,18 +156,41 @@ validate_inc_4523() {
 validate_inc_4524() {
     local ALL_PASS=true
     
-    # Check 1: SSH source restriction
+    # Check 1: SSH source restriction (including bastion)
+    local BASTION_NSG="nsg-bastion-${DEPLOYMENT_ID}"
     local WEB_NSG="nsg-web-${DEPLOYMENT_ID}"
-    local SSH_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
+    local API_NSG="nsg-api-${DEPLOYMENT_ID}"
+    local DB_NSG="nsg-database-${DEPLOYMENT_ID}"
+    local BASTION_SSH_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
+        --nsg-name "$BASTION_NSG" -n allow-ssh-inbound \
+        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*")
+    local WEB_SSH_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
         --nsg-name "$WEB_NSG" -n allow-ssh \
         --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*")
+    local API_SSH_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
+        --nsg-name "$API_NSG" -n allow-ssh \
+        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*")
+    local DB_SSH_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
+        --nsg-name "$DB_NSG" -n allow-ssh \
+        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*")
+
+    if [ "$BASTION_SSH_SOURCE" == "*" ] || [ "$BASTION_SSH_SOURCE" == "0.0.0.0/0" ] || [ "$BASTION_SSH_SOURCE" == "Internet" ]; then
+        ALL_PASS=false
+    fi
     
-    if [ "$SSH_SOURCE" == "*" ] || [ "$SSH_SOURCE" == "0.0.0.0/0" ] || [ "$SSH_SOURCE" == "Internet" ]; then
+    if [ "$WEB_SSH_SOURCE" == "*" ] || [ "$WEB_SSH_SOURCE" == "0.0.0.0/0" ] || [ "$WEB_SSH_SOURCE" == "Internet" ]; then
+        ALL_PASS=false
+    fi
+
+    if [ "$API_SSH_SOURCE" == "*" ] || [ "$API_SSH_SOURCE" == "0.0.0.0/0" ] || [ "$API_SSH_SOURCE" == "Internet" ]; then
+        ALL_PASS=false
+    fi
+
+    if [ "$DB_SSH_SOURCE" == "*" ] || [ "$DB_SSH_SOURCE" == "0.0.0.0/0" ] || [ "$DB_SSH_SOURCE" == "Internet" ]; then
         ALL_PASS=false
     fi
     
     # Check 2: Database source restriction
-    local DB_NSG="nsg-database-${DEPLOYMENT_ID}"
     local PG_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
         --nsg-name "$DB_NSG" -n postgres-access \
         --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "")
@@ -189,7 +212,7 @@ validate_inc_4524() {
         --nsg-name "$WEB_NSG" -n allow-icmp \
         --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "deleted")
     
-    if [ "$ICMP_SOURCE" == "*" ]; then
+    if [ "$ICMP_SOURCE" == "*" ] || [ "$ICMP_SOURCE" == "0.0.0.0/0" ] || [ "$ICMP_SOURCE" == "Internet" ]; then
         ALL_PASS=false
     fi
     

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -115,9 +115,9 @@ You're on call. Four tickets just came in. Your job: diagnose and fix.
 
 > "Our quarterly security scan flagged several issues with the network segmentation:
 > 
-> 1. SSH is accessible from the internet on some hosts, including bastion (only your trusted source IP/CIDR should be allowed)
-> 2. Database accepts connections from too broad a range (should be API tier only)
-> 3. ICMP is open from anywhere
+> 1. SSH is accessible from the internet on all hosts — bastion should only allow SSH from your trusted source IP/CIDR, and internal hosts (web, API, database) should only allow SSH from the bastion subnet
+> 2. Database accepts connections on port 5432 from too broad a range — it should only accept connections from the API subnet (10.0.2.0/24)
+> 3. ICMP is open from anywhere — it should only be allowed from the bastion subnet
 > 
 > These need to be tightened up before our compliance review next week."
 

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -115,7 +115,7 @@ You're on call. Four tickets just came in. Your job: diagnose and fix.
 
 > "Our quarterly security scan flagged several issues with the network segmentation:
 > 
-> 1. SSH is accessible from the internet on some hosts (should only be via bastion)
+> 1. SSH is accessible from the internet on some hosts, including bastion (only your trusted source IP/CIDR should be allowed)
 > 2. Database accepts connections from too broad a range (should be API tier only)
 > 3. ICMP is open from anywhere
 > 


### PR DESCRIPTION
This pull request strengthens the security group and network security group validation scripts for AWS and Azure, and clarifies the compliance requirements in the documentation for AWS, Azure, and GCP. The main focus is to ensure that SSH, database, and ICMP access are tightly restricted according to best practices and compliance requirements.

**Validation Script Enhancements:**

* **AWS (`aws/scripts/validate.sh`):**
  - Adds explicit validation to ensure the bastion host only allows SSH from a trusted source (not internet-open) and that internal hosts only allow SSH from the bastion security group.
  - Renumbers and clarifies checks for database and ICMP restrictions to match the updated requirements. [[1]](diffhunk://#diff-315114966825c3c17707fe624cfae2125b3aa95e5126e3b1ef7fc282dc61163dL190-R200) [[2]](diffhunk://#diff-315114966825c3c17707fe624cfae2125b3aa95e5126e3b1ef7fc282dc61163dL214-R224)

* **Azure (`azure/scripts/validate.sh`):**
  - Expands SSH source validation to check all tiers (bastion, web, API, database) and ensure none are internet-accessible.
  - Improves ICMP restriction checks to disallow open access from the internet or any source.

**Documentation Updates:**

* **AWS, Azure, GCP (`aws/README.md`, `azure/README.md`, `gcp/README.md`):**
  - Updates the security scan findings to clarify that SSH should only be allowed from trusted sources or bastion, database access should be tightly limited (API security group or subnet only), and ICMP should only be allowed from bastion. [[1]](diffhunk://#diff-d1f3cfb2cd1f80df61fb16ed5304cf357114bed4c6b1a8a57a155328c5f581f7L117-R119) [[2]](diffhunk://#diff-5e6e6f1ff7cb41abdbc5493a9f7d14f284c83f77b201c6deda51d91d3dbb1a17L117-R119) [[3]](diffhunk://#diff-2812cc369ae84566241284e26ac29150b310371be7a4519ebc189331676032b8L118-R120)