### PR TITLE
Script enhancements - region output and gcp delete script

### DIFF
--- a/aws/scripts/setup.sh
+++ b/aws/scripts/setup.sh
@@ -106,6 +106,10 @@ terraform output -raw ssh_private_key > ~/.ssh/netlab-key 2>/dev/null
 chmod 600 ~/.ssh/netlab-key
 echo -e "  ${GREEN}✓${NC} SSH key saved to ~/.ssh/netlab-key"
 
+# Show deployment region
+REGION=$(terraform output -raw region 2>/dev/null)
+echo -e "  ${GREEN}✓${NC} Region: $REGION"
+
 echo ""
 echo -e "${BLUE}============================================${NC}"
 echo -e "${BLUE}   READY TO START!${NC}"

--- a/aws/terraform/outputs.tf
+++ b/aws/terraform/outputs.tf
@@ -1,3 +1,8 @@
+output "region" {
+  description = "AWS region where resources are deployed"
+  value       = var.aws_region
+}
+
 output "deployment_id" {
   description = "Unique deployment identifier"
   value       = random_id.deployment.hex

--- a/azure/scripts/setup.sh
+++ b/azure/scripts/setup.sh
@@ -105,6 +105,10 @@ terraform output -raw ssh_private_key > ~/.ssh/netlab-key 2>/dev/null
 chmod 600 ~/.ssh/netlab-key
 echo -e "  ${GREEN}✓${NC} SSH key saved to ~/.ssh/netlab-key"
 
+# Show deployment region
+LOCATION=$(terraform output -raw location 2>/dev/null)
+echo -e "  ${GREEN}✓${NC} Region: $LOCATION"
+
 echo ""
 echo -e "${BLUE}============================================${NC}"
 echo -e "${BLUE}   READY TO START!${NC}"

--- a/azure/terraform/outputs.tf
+++ b/azure/terraform/outputs.tf
@@ -1,3 +1,8 @@
+output "location" {
+  description = "Azure region where resources are deployed"
+  value       = var.location
+}
+
 output "deployment_id" {
   description = "Unique deployment identifier"
   value       = random_id.deployment.hex

--- a/gcp/scripts/destroy.sh
+++ b/gcp/scripts/destroy.sh
@@ -65,15 +65,28 @@ if [[ ! $REPLY == "yes" ]]; then
     exit 0
 fi
 
-# Remove ad-hoc firewall rules created during lab fixes
+# Remove ad-hoc firewall rules created during lab fixes.
+# Delete known rule names first, then sweep for any remaining rules in the VPC.
 if [ -n "$PROJECT_ID" ] && [ -n "$DEPLOYMENT_ID" ] && command -v gcloud >/dev/null 2>&1; then
-    EXTRA_RULES=("allow-web-to-api-8080-${DEPLOYMENT_ID}")
+    EXTRA_RULES=(
+        "allow-web-to-api-${DEPLOYMENT_ID}"
+        "allow-web-to-api-8080-${DEPLOYMENT_ID}"
+    )
     for RULE in "${EXTRA_RULES[@]}"; do
         if gcloud compute firewall-rules describe "$RULE" --project "$PROJECT_ID" >/dev/null 2>&1; then
             echo "Deleting firewall rule: $RULE"
-            gcloud compute firewall-rules delete "$RULE" --project "$PROJECT_ID" -q >/dev/null 2>&1 || true
+            gcloud compute firewall-rules delete "$RULE" --project "$PROJECT_ID" -q || true
         fi
     done
+    # Catch-all: delete any remaining non-Terraform firewall rules whose name
+    # contains the deployment ID (handles rules students may have created).
+    for RULE in $(gcloud compute firewall-rules list --project "$PROJECT_ID" \
+        --format="value(name)" 2>/dev/null | grep "${DEPLOYMENT_ID}" || true); do
+        echo "Deleting leftover firewall rule: $RULE"
+        gcloud compute firewall-rules delete "$RULE" --project "$PROJECT_ID" -q 2>/dev/null || true
+    done
+else
+    echo "DEBUG: Skipped firewall cleanup (PROJECT_ID='${PROJECT_ID}', DEPLOYMENT_ID='${DEPLOYMENT_ID}')"
 fi
 
 # Remove Cloud DNS records so the managed zone can be deleted
@@ -149,11 +162,39 @@ if [ -n "$PROJECT_ID" ] && command -v gcloud >/dev/null 2>&1; then
     done
 fi
 
-# Destroy
+# Destroy — retry once if a leftover firewall rule blocks VPC deletion
+DESTROY_CMD="terraform destroy -auto-approve"
 if [ -n "$PROJECT_ID" ]; then
-    TF_VAR_project_id="$PROJECT_ID" terraform destroy -auto-approve
-else
-    terraform destroy -auto-approve
+    DESTROY_CMD="TF_VAR_project_id=\"$PROJECT_ID\" terraform destroy -auto-approve"
+fi
+
+set +e
+DESTROY_OUTPUT=$(eval "$DESTROY_CMD" 2>&1)
+DESTROY_EXIT=$?
+set -e
+
+echo "$DESTROY_OUTPUT"
+
+if [ $DESTROY_EXIT -ne 0 ]; then
+    # Extract blocking firewall rule names from the error output
+    BLOCKING_RULES=$(echo "$DESTROY_OUTPUT" | grep -oE "global/firewalls/[a-zA-Z0-9_-]+" | sed 's|global/firewalls/||g' | sort -u)
+    if [ -n "$BLOCKING_RULES" ] && [ -n "$PROJECT_ID" ]; then
+        echo ""
+        echo "Detected firewall rules blocking VPC deletion. Cleaning up..."
+        for RULE in $BLOCKING_RULES; do
+            echo "Deleting blocking firewall rule: $RULE"
+            gcloud compute firewall-rules delete "$RULE" --project "$PROJECT_ID" -q 2>&1 || true
+        done
+        echo "Retrying destroy..."
+        if [ -n "$PROJECT_ID" ]; then
+            TF_VAR_project_id="$PROJECT_ID" terraform destroy -auto-approve
+        else
+            terraform destroy -auto-approve
+        fi
+    else
+        echo "Terraform destroy failed. See error above."
+        exit 1
+    fi
 fi
 
 # Clean up SSH key

--- a/gcp/scripts/setup.sh
+++ b/gcp/scripts/setup.sh
@@ -135,6 +135,10 @@ terraform output -raw ssh_private_key > ~/.ssh/netlab-key 2>/dev/null
 chmod 600 ~/.ssh/netlab-key
 echo -e "  ${GREEN}✓${NC} SSH key saved to ~/.ssh/netlab-key"
 
+# Show deployment region
+REGION=$(terraform output -raw region 2>/dev/null)
+echo -e "  ${GREEN}✓${NC} Region: $REGION"
+
 echo ""
 echo -e "${BLUE}============================================${NC}"
 echo -e "${BLUE}   READY TO START!${NC}"

--- a/gcp/terraform/outputs.tf
+++ b/gcp/terraform/outputs.tf
@@ -3,6 +3,11 @@ output "project_id" {
   value       = var.project_id
 }
 
+output "region" {
+  description = "GCP region where resources are deployed"
+  value       = var.region
+}
+
 output "deployment_id" {
   description = "Unique deployment identifier"
   value       = random_id.deployment.hex


### PR DESCRIPTION
This pull request improves the deployment and teardown scripts for AWS, Azure, and GCP by adding clearer region output and making GCP firewall cleanup and destroy operations more robust. The main changes are grouped below:

**Deployment Region Output:**
* Added a new Terraform output for the deployment region in AWS (`outputs.tf` as `region`), Azure (`outputs.tf` as `location`), and GCP (`outputs.tf` as `region`) so that scripts can display the region where resources are deployed. [[1]](diffhunk://#diff-33f743d860e5356d18668e786f80bdc6aba0e768ab7f31ccb0637320e65f7a71R1-R5) [[2]](diffhunk://#diff-f0a7c4c30702a4c4ae3b7cf31727658d267f9db2caeec43dccbda40f2d36a72bR1-R5) [[3]](diffhunk://#diff-7b7f524fc262e0084af32672aadd68b10459b290c37c2d69fdc7337c4f54c875R6-R10)
* Updated the `setup.sh` scripts for AWS, Azure, and GCP to display the deployment region to the user after provisioning. [[1]](diffhunk://#diff-74475dec73bca699a018dcb5369832fbc2b15e54910336510c0c1b5542609386R109-R112) [[2]](diffhunk://#diff-930dca45925880c4c78bca3529fdc13e328b4a0472ac6d9a8776df378e508625R108-R111) [[3]](diffhunk://#diff-682674ef7abc6ac1277c8f72b0a7e0918590e95211ff9e096dc99424f86dd228R138-R141)

**GCP Firewall Rule Cleanup and Destroy Improvements:**
* Enhanced `gcp/scripts/destroy.sh` to delete both known and any remaining ad-hoc firewall rules containing the deployment ID, ensuring a cleaner teardown.
* Improved the GCP destroy process to retry the `terraform destroy` command if it fails due to blocking firewall rules. The script now parses error output, deletes any blocking rules, and retries the destroy operation, providing better resilience and feedback.