### PR TITLE
Fix validation scripts to handle carriage return characters in NSG queries

### DIFF
--- a/aws/scripts/validate.sh
+++ b/aws/scripts/validate.sh
@@ -172,6 +172,8 @@ validate_inc_4524() {
         --query "SecurityGroups[0].IpPermissions[?FromPort==\`22\` && ToPort==\`22\`].IpRanges[].CidrIp" --output text 2>/dev/null)
     local BASTION_SSH_SG_SOURCES=$(aws ec2 describe-security-groups --group-ids "$BASTION_SG_ID" \
         --query "SecurityGroups[0].IpPermissions[?FromPort==\`22\` && ToPort==\`22\`].UserIdGroupPairs[].GroupId" --output text 2>/dev/null)
+    BASTION_SSH_CIDRS=$(printf '%s' "$BASTION_SSH_CIDRS" | tr -d '\r')
+    BASTION_SSH_SG_SOURCES=$(printf '%s' "$BASTION_SSH_SG_SOURCES" | tr -d '\r')
 
     if [ -z "$BASTION_SSH_CIDRS" ] || [ -n "$BASTION_SSH_SG_SOURCES" ] || echo "$BASTION_SSH_CIDRS" | grep -q "0.0.0.0/0"; then
         ALL_PASS=false
@@ -183,6 +185,8 @@ validate_inc_4524() {
             --query "SecurityGroups[0].IpPermissions[?FromPort==\`22\` && ToPort==\`22\`].IpRanges[].CidrIp" --output text 2>/dev/null)
         local SSH_SG_SOURCES=$(aws ec2 describe-security-groups --group-ids "$SG_ID" \
             --query "SecurityGroups[0].IpPermissions[?FromPort==\`22\` && ToPort==\`22\`].UserIdGroupPairs[].GroupId" --output text 2>/dev/null)
+        SSH_CIDRS=$(printf '%s' "$SSH_CIDRS" | tr -d '\r')
+        SSH_SG_SOURCES=$(printf '%s' "$SSH_SG_SOURCES" | tr -d '\r')
 
         if [ -n "$SSH_CIDRS" ] || [ -z "$SSH_SG_SOURCES" ]; then
             ALL_PASS=false
@@ -204,6 +208,9 @@ validate_inc_4524() {
         --query "SecurityGroups[0].IpPermissions[?IpProtocol=='tcp' && FromPort==\`5432\` && ToPort==\`5432\`].UserIdGroupPairs[].GroupId" --output text 2>/dev/null)
     local DB_WIDE_RULES=$(aws ec2 describe-security-groups --group-ids "$DB_SG_ID" \
         --query "SecurityGroups[0].IpPermissions[?IpProtocol=='tcp' && FromPort<=\`5432\` && ToPort>=\`5432\` && (FromPort!=\`5432\` || ToPort!=\`5432\`)]" --output text 2>/dev/null)
+    DB_CIDRS=$(printf '%s' "$DB_CIDRS" | tr -d '\r')
+    DB_SG_SOURCES=$(printf '%s' "$DB_SG_SOURCES" | tr -d '\r')
+    DB_WIDE_RULES=$(printf '%s' "$DB_WIDE_RULES" | tr -d '\r')
 
     if [ -n "$DB_WIDE_RULES" ]; then
         ALL_PASS=false
@@ -226,6 +233,8 @@ validate_inc_4524() {
         --query "SecurityGroups[0].IpPermissions[?IpProtocol==\`icmp\`].IpRanges[].CidrIp" --output text 2>/dev/null)
     local ICMP_SG_SOURCES=$(aws ec2 describe-security-groups --group-ids "$WEB_SG_ID" \
         --query "SecurityGroups[0].IpPermissions[?IpProtocol==\`icmp\`].UserIdGroupPairs[].GroupId" --output text 2>/dev/null)
+    ICMP_CIDRS=$(printf '%s' "$ICMP_CIDRS" | tr -d '\r')
+    ICMP_SG_SOURCES=$(printf '%s' "$ICMP_SG_SOURCES" | tr -d '\r')
 
     if [ -n "$ICMP_CIDRS" ] || [ -z "$ICMP_SG_SOURCES" ]; then
         ALL_PASS=false

--- a/azure/scripts/validate.sh
+++ b/azure/scripts/validate.sh
@@ -161,18 +161,18 @@ validate_inc_4524() {
     local WEB_NSG="nsg-web-${DEPLOYMENT_ID}"
     local API_NSG="nsg-api-${DEPLOYMENT_ID}"
     local DB_NSG="nsg-database-${DEPLOYMENT_ID}"
-    local BASTION_SSH_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
+    local BASTION_SSH_SOURCE=$( (az network nsg rule show -g "$RESOURCE_GROUP" \
         --nsg-name "$BASTION_NSG" -n allow-ssh-inbound \
-        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*")
-    local WEB_SSH_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
+        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*") | tr -d '\r')
+    local WEB_SSH_SOURCE=$( (az network nsg rule show -g "$RESOURCE_GROUP" \
         --nsg-name "$WEB_NSG" -n allow-ssh \
-        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*")
-    local API_SSH_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
+        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*") | tr -d '\r')
+    local API_SSH_SOURCE=$( (az network nsg rule show -g "$RESOURCE_GROUP" \
         --nsg-name "$API_NSG" -n allow-ssh \
-        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*")
-    local DB_SSH_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
+        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*") | tr -d '\r')
+    local DB_SSH_SOURCE=$( (az network nsg rule show -g "$RESOURCE_GROUP" \
         --nsg-name "$DB_NSG" -n allow-ssh \
-        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*")
+        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "*") | tr -d '\r')
 
     if [ "$BASTION_SSH_SOURCE" == "*" ] || [ "$BASTION_SSH_SOURCE" == "0.0.0.0/0" ] || [ "$BASTION_SSH_SOURCE" == "Internet" ]; then
         ALL_PASS=false
@@ -191,9 +191,9 @@ validate_inc_4524() {
     fi
     
     # Check 2: Database source restriction
-    local PG_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
+    local PG_SOURCE=$( (az network nsg rule show -g "$RESOURCE_GROUP" \
         --nsg-name "$DB_NSG" -n postgres-access \
-        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "")
+        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "") | tr -d '\r')
     
     if [ "$PG_SOURCE" != "10.0.2.0/24" ]; then
         ALL_PASS=false
@@ -208,9 +208,9 @@ validate_inc_4524() {
     fi
     
     # Check 4: ICMP restriction
-    local ICMP_SOURCE=$(az network nsg rule show -g "$RESOURCE_GROUP" \
+    local ICMP_SOURCE=$( (az network nsg rule show -g "$RESOURCE_GROUP" \
         --nsg-name "$WEB_NSG" -n allow-icmp \
-        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "deleted")
+        --query "sourceAddressPrefix" -o tsv 2>/dev/null || echo "deleted") | tr -d '\r')
     
     if [ "$ICMP_SOURCE" == "*" ] || [ "$ICMP_SOURCE" == "0.0.0.0/0" ] || [ "$ICMP_SOURCE" == "Internet" ]; then
         ALL_PASS=false

--- a/gcp/scripts/validate.sh
+++ b/gcp/scripts/validate.sh
@@ -201,8 +201,8 @@ validate_inc_4524() {
     local SSH_WORLD=0
     for RULE in "allow-ssh-bastion-${DEPLOYMENT_ID}" "allow-ssh-web-${DEPLOYMENT_ID}" "allow-ssh-api-${DEPLOYMENT_ID}" "allow-ssh-db-${DEPLOYMENT_ID}"; do
         local SSH_SOURCE
-        SSH_SOURCE=$(gcloud compute firewall-rules describe "$RULE" \
-            --project "$PROJECT_ID" --format="value(sourceRanges)" 2>/dev/null || echo "*")
+        SSH_SOURCE=$( (gcloud compute firewall-rules describe "$RULE" \
+            --project "$PROJECT_ID" --format="value(sourceRanges)" 2>/dev/null || echo "*") | tr -d '\r')
         if echo "$SSH_SOURCE" | grep -q "0.0.0.0/0"; then
             SSH_WORLD=1
         fi
@@ -214,8 +214,8 @@ validate_inc_4524() {
 
     # Check 2: Database source restriction
     local PG_SOURCE
-    PG_SOURCE=$(gcloud compute firewall-rules describe "allow-postgres-${DEPLOYMENT_ID}" \
-        --project "$PROJECT_ID" --format="value(sourceRanges)" 2>/dev/null || echo "")
+    PG_SOURCE=$( (gcloud compute firewall-rules describe "allow-postgres-${DEPLOYMENT_ID}" \
+        --project "$PROJECT_ID" --format="value(sourceRanges)" 2>/dev/null || echo "") | tr -d '\r')
 
     if ! echo "$PG_SOURCE" | grep -q "10.0.2.0/24"; then
         ALL_PASS=false
@@ -223,8 +223,8 @@ validate_inc_4524() {
 
     # Check 3: ICMP restriction
     local ICMP_SOURCE
-    ICMP_SOURCE=$(gcloud compute firewall-rules describe "allow-icmp-${DEPLOYMENT_ID}" \
-        --project "$PROJECT_ID" --format="value(sourceRanges)" 2>/dev/null || echo "*")
+    ICMP_SOURCE=$( (gcloud compute firewall-rules describe "allow-icmp-${DEPLOYMENT_ID}" \
+        --project "$PROJECT_ID" --format="value(sourceRanges)" 2>/dev/null || echo "*") | tr -d '\r')
 
     if echo "$ICMP_SOURCE" | grep -q "0.0.0.0/0"; then
         ALL_PASS=false


### PR DESCRIPTION
This pull request updates the `validate_inc_4524()` function in the AWS, Azure, and GCP validation scripts to ensure that all network rule source values are normalized by removing carriage return (`\r`) characters. This helps prevent issues caused by inconsistent line endings, especially when scripts are run on different operating systems or when processing command output.

The most important changes are:

**Cross-Platform Line Ending Normalization:**

* All relevant variables that capture source address or range values from AWS, Azure, and GCP CLI commands are now piped through `tr -d '\r'` to remove carriage returns and ensure consistent line endings. This affects SSH, database, and ICMP rule checks in all three cloud provider scripts. [[1]](diffhunk://#diff-315114966825c3c17707fe624cfae2125b3aa95e5126e3b1ef7fc282dc61163dR175-R176) [[2]](diffhunk://#diff-315114966825c3c17707fe624cfae2125b3aa95e5126e3b1ef7fc282dc61163dR188-R189) [[3]](diffhunk://#diff-315114966825c3c17707fe624cfae2125b3aa95e5126e3b1ef7fc282dc61163dR211-R213) [[4]](diffhunk://#diff-315114966825c3c17707fe624cfae2125b3aa95e5126e3b1ef7fc282dc61163dR236-R237) [[5]](diffhunk://#diff-18931bded3547b00998bcb2f8fdbef57da9fda13ae4c04e02255399b5cd6ce5eL164-R175) [[6]](diffhunk://#diff-18931bded3547b00998bcb2f8fdbef57da9fda13ae4c04e02255399b5cd6ce5eL194-R196) [[7]](diffhunk://#diff-18931bded3547b00998bcb2f8fdbef57da9fda13ae4c04e02255399b5cd6ce5eL211-R213) [[8]](diffhunk://#diff-71591e89bf99321bc78f2b99398e04e008bf3b1e8b9337ab99c142c08275a8a9L204-R205) [[9]](diffhunk://#diff-71591e89bf99321bc78f2b99398e04e008bf3b1e8b9337ab99c142c08275a8a9L217-R227)

**Robustness Improvements:**

* The normalization is applied immediately after capturing command output, ensuring that subsequent validation logic works reliably regardless of the environment in which the scripts are executed. [[1]](diffhunk://#diff-18931bded3547b00998bcb2f8fdbef57da9fda13ae4c04e02255399b5cd6ce5eL164-R175) [[2]](diffhunk://#diff-71591e89bf99321bc78f2b99398e04e008bf3b1e8b9337ab99c142c08275a8a9L204-R205)

These changes increase the reliability and portability of the validation scripts across different platforms.